### PR TITLE
Add conda-forge-admin to allowed users

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -1,6 +1,10 @@
 {
   "users": [
     {
+      "github": "conda-forge-admin",
+      "id": 16698198
+    },
+    {
       "github": "jaimergp",
       "id": 2559438
     },


### PR DESCRIPTION
To obtain access to the CI server, you must complete the form below:

- [ ] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [ ] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->

If the conda-forge-admin will be opening PRs/migrations on feedstocks that use this CI, then it should also have permission to use this CI?

https://github.com/conda-forge/libmagma-feedstock/pull/14