### PR TITLE
Add njzjz to the gpu list

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -27,6 +27,10 @@
     {
       "github": "RaulPPelaez",
       "id": 13015792
+    },
+    {
+      "github": "njzjz",
+      "id": 9496702
     }
   ]
 }


### PR DESCRIPTION
To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->

xref: https://github.com/conda-forge/pytorch-cpu-feedstock/pull/224#issuecomment-1989985240