### PR TITLE
Typo docs/setup.md -> docs/openstack.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These runners run ISOs derived from Ubuntu 22.04. Images are built with the inst
 
 ## Limitations
 
-* Concurrency depends on available resources. Only 4 GPUs can be exposed to the VMs at a time; expect queues. This is not per repository, but a server-wide limitation. See [docs/setup.md](/docs/setup.md) for details.
+* Concurrency depends on available resources. Only 4 GPUs can be exposed to the VMs at a time; expect queues. This is not per repository, but a server-wide limitation. See [docs/openstack.md](/docs/openstack.md) for details.
 * We have not yet implemented a time limit per job. Please be mindful of this and try to keep your jobs as short as possible. This might change in the future.
 
 ## Support


### PR DESCRIPTION
The `docs/setup.md` file doesn't exist, probably a typo from https://github.com/Quansight/open-gpu-server/pull/8? Assuming that it should be [`docs/openstack.md`](https://github.com/Quansight/open-gpu-server/blob/656397ad5dafd6817c7b2b7f8bd9ae6c6e59234a/docs/openstack.md) instead.
