### PR TITLE
added joehiggi1758 to open gpu server json access file

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -59,6 +59,10 @@
     {
       "github": "seanlaw",
       "id": 7473521
-   }
+    },
+    {
+      "github": "joehiggi1758",
+      "id": 46200959
+    }
   ]
 }


### PR DESCRIPTION
To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

The purpose of this access is to assist in the development and deployment of GPU unit testing for STUMPY.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->
