### PR TITLE
add hadim to allowed users

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -71,6 +71,10 @@
     {
       "github": "Tobias-Fischer",
       "id": 5497832
+    },
+    {
+      "github": "hadim",
+      "id": 528003
     }
   ]
 }


### PR DESCRIPTION
To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->

For https://github.com/conda-forge/xformers-feedstock/pull/33