### PR TITLE
chore: add beckermr to cirun users

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -75,6 +75,10 @@
     {
       "github": "mgorny",
       "id": 110765
+    },
+    {
+      "github": "beckermr",
+      "id": 5296416
     }
   ]
 }


### PR DESCRIPTION
To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->
