### PR TITLE
Add Hofer-Julian to list of allowed users

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -119,6 +119,10 @@
     {
       "github": "haecker-felix",
       "id": 6001248
+    },
+    {
+      "github": "Hofer-Julian",
+      "id": 30049909
     }
   ]
 }


### PR DESCRIPTION
Same reason as with https://github.com/Quansight/open-gpu-server/pull/65.

I'd like to use it with this feedstock: https://github.com/conda-forge/webkit2gtk4.1-feedstock

To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->
