### PR TITLE
Add @traversaro to the list of allowed users

### DIFF
--- a/access/conda-forge-users.json
+++ b/access/conda-forge-users.json
@@ -123,6 +123,10 @@
     {
       "github": "Hofer-Julian",
       "id": 30049909
+    },
+    {
+      "github": "traversaro",
+      "id": 1857049
     }
   ]
 }


### PR DESCRIPTION
I am mantainer of `onnxruntime` and contributors to other repos with cirun enable (see https://github.com/conda-forge/onnxruntime-feedstock/pull/149#issuecomment-3186022404 and https://github.com/conda-forge/jaxlib-feedstock/pull/322), so it would be convenient to be cirun enabled.

To obtain access to the CI server, you must complete the form below:

- [x] I have read the [Terms of Service](https://github.com/Quansight/open-gpu-server/blob/main/TOS.md) and [Privacy Policy](https://quansight.com/privacy-policy/) and accept them.
- [x] I have included my GitHub username and unique identifier to the relevant `access/*.json` file.

<!-- You can obtain your Github identifier via https://api.github.com/users/__username__ -->
