### PR TITLE
also install nvidia-utils

### DIFF
--- a/vm-images/elements/cuda/post-install.d/05-cuda-install
+++ b/vm-images/elements/cuda/post-install.d/05-cuda-install
@@ -35,6 +35,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt install -y ubuntu-drivers-common
 # The --gpgpu flag is required for server drivers (-server suffix)
 # See: https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/
 DEBIAN_FRONTEND=noninteractive sudo ubuntu-drivers install --gpgpu nvidia:580-server
+DEBIAN_FRONTEND=noninteractive sudo apt install nvidia-utils-580-server
 echo "Put nvidia drivers on hold: DO NOT UPGRADE basically"
 dpkg-query -W --showformat='${Package} ${Status}\n' | grep -v deinstall | awk '{ print $1 }' | grep -E '(nvidia|libnvidia|linux-.+-nvidia)-.*580' | xargs -r -L 1 sudo apt-mark hold
 


### PR DESCRIPTION
The changes in #83 caused `nvidia-smi` to not be present in the image anymore ([logs](https://github.com/conda-forge/tinygrad-feedstock/actions/runs/21056008471/job/61720613207)):
```
 │ │ $SRC_DIR/conda_build.sh: line 9: nvidia-smi: command not found
 ```
Reading the [docs](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/) referenced by #83
https://github.com/Quansight/open-gpu-server/blob/fa27a2f53553c4c727f999cf1779b67d3f9ce3a4/vm-images/elements/cuda/post-install.d/05-cuda-install#L36
more closely, they say
> Let’s assume we want to install the 535-server driver (listed as nvidia-driver-535-server):
> ```
> sudo ubuntu-drivers install --gpgpu nvidia:535-server
> ```
> You will also want to install the following additional components:
> ```
> sudo apt install nvidia-utils-535-server
> ```

So let's add the utils package as well.