### PR TITLE
Increase SSH connection attempts to 10

### DIFF
--- a/.github/workflows/build-images-ssh.yml
+++ b/.github/workflows/build-images-ssh.yml
@@ -35,6 +35,7 @@ jobs:
             User ${{ secrets.SSH_USER }}
             IdentityFile ~/.ssh/id_rsa
             StrictHostKeyChecking no
+            ConnectionAttempts 10
           EOF
           chmod 600 ~/.ssh/config
 


### PR DESCRIPTION
The SSH tunnel is very spotty and fails often. Let's see if we can retry within SSH more succesfully... As an example, the GPU VM in this [run](https://github.com/Quansight/open-gpu-server/actions/runs/22062721881/job/63767626944) hasn't succeeded after 10 retries.